### PR TITLE
Default system name to latest in history as last resort

### DIFF
--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -236,7 +236,7 @@ in the directory of the current buffer."
          (prompt (or prompt "System"))
          (system-names (sly-eval `(slynk-asdf:list-asdf-systems)))
          (default-value
-           (or default-value (sly-asdf-find-current-system)))
+           (or default-value (sly-asdf-find-current-system) (first sly-asdf-system-history)))
          (prompt (concat prompt (if default-value
                                     (format " (default `%s'): " default-value)
                                   ": "))))


### PR DESCRIPTION
This defaults the system name to the latest history item if we fail to figure it out from scanning.