### PR TITLE
Remove deprecated call to asdf internal function

### DIFF
--- a/slynk-asdf.lisp
+++ b/slynk-asdf.lisp
@@ -116,7 +116,7 @@ already knows."
   (let* ((system (asdf:find-system name))
          (files (mapcar #'namestring
                         (cons
-                         (asdf:system-definition-pathname system)
+                         (asdf:system-source-file system)
                          (asdf-component-source-files system))))
          (main-file (find name files
                           :test #'equalp :key #'pathname-name :start 1)))
@@ -414,7 +414,7 @@ already knows."
 (defmethod xref-doit ((type (eql :depends-on)) thing)
   (when (typep thing '(or string symbol))
     (loop for dependency in (who-depends-on thing)
-          for asd-file = (asdf:system-definition-pathname dependency)
+          for asd-file = (asdf:system-source-file dependency)
           when asd-file
             collect (list dependency
                         (slynk-backend:make-location


### PR DESCRIPTION
system-definition-pathname is deprecated. replace the extant calls
with system-source-file, as recommended by the asdf authors.