### PR TITLE
Add to contrib after loading 'sly.

### DIFF
--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -289,7 +289,8 @@ in the directory of the current buffer."
 
 
 ;;;###autoload
-(add-to-list 'sly-contribs 'sly-asdf 'append)
+(with-eval-after-load 'sly
+  (add-to-list 'sly-contribs 'sly-asdf 'append))
 
 
 (provide 'sly-asdf)


### PR DESCRIPTION
Else the load would fail if the package happens to be loaded before SLY.