### PR TITLE
Asdf open system

### DIFF
--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -110,11 +110,11 @@ buffer's working directory"
   (interactive (list (sly-asdf-read-system-name) nil t))
   (when (or load
             (and interactive
-                 (not (sly-eval `(sly:asdf-system-loaded-p ,name)))
+                 (not (sly-eval `(slynk-asdf:asdf-system-loaded-p ,name)))
                  (y-or-n-p "Load it? ")))
-    (sly-load-system name))
+    (sly-asdf-load-system name))
   (sly-eval-async
-      `(swank:asdf-system-files ,name)
+      `(slynk-asdf:asdf-system-files ,name)
     (lambda (files)
       (when files
         (let ((files (mapcar 'sly-from-lisp-filename

--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -41,7 +41,7 @@
   '(("load-system" . sly-asdf-load-system)
     ("reload-system" . sly-asdf-reload-system)
     ("browse-system" . sly-asdf-browse-system)
-    ("open-system" . sly-open-system)
+    ("open-system" . sly-asdf-open-system)
     ("save-system" . sly-asdf-save-system)))
 
 
@@ -105,7 +105,7 @@ buffer's working directory"
       (when directory
         (dired (sly-from-lisp-filename directory))))))
 
-(defun sly-open-system (name &optional load interactive)
+(defun sly-asdf-open-system (name &optional load interactive)
   "Open all files in an ASDF system."
   (interactive (list (sly-asdf-read-system-name) nil t))
   (when (or load

--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -106,7 +106,7 @@ buffer's working directory"
         (dired (sly-from-lisp-filename directory))))))
 
 (defun sly-asdf-open-system (name &optional load interactive)
-  "Open all files in an ASDF system."
+  "Open all files implicated in an ASDF system, in separate emacs buffers."
   (interactive (list (sly-asdf-read-system-name) nil t))
   (when (or load
             (and interactive

--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -41,6 +41,7 @@
   '(("load-system" . sly-asdf-load-system)
     ("reload-system" . sly-asdf-reload-system)
     ("browse-system" . sly-asdf-browse-system)
+    ("open-system" . sly-open-system)
     ("save-system" . sly-asdf-save-system)))
 
 
@@ -104,6 +105,22 @@ buffer's working directory"
       (when directory
         (dired (sly-from-lisp-filename directory))))))
 
+(defun sly-open-system (name &optional load interactive)
+  "Open all files in an ASDF system."
+  (interactive (list (sly-asdf-read-system-name) nil t))
+  (when (or load
+            (and interactive
+                 (not (sly-eval `(sly:asdf-system-loaded-p ,name)))
+                 (y-or-n-p "Load it? ")))
+    (sly-load-system name))
+  (sly-eval-async
+      `(swank:asdf-system-files ,name)
+    (lambda (files)
+      (when files
+        (let ((files (mapcar 'sly-from-lisp-filename
+                             (nreverse files))))
+          (find-file-other-window (car files))
+          (mapc 'find-file (cdr files)))))))
 
 (defun sly-asdf-rgrep-system (sys-name regexp)
   "Run `rgrep' for REGEXP for SYS-NAME on the base directory of an ASDF system."


### PR DESCRIPTION
port of slime command to open all the files referenced in an asdf defsystem into separate buffers in Emacs. I used this all the time in Slime, so felt the need to add it to Sly.