### PR TITLE
Fix compile warnings in `sly-asdf.el`

### DIFF
--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -343,7 +343,7 @@ in the directory of the current buffer."
     ;; Conditionally show compilation log and other options defined in settings
     (run-hook-with-args 'sly-compilation-finished-hook successp notes buffer t)))
 
-    
+
 
 ;;;###autoload
 (with-eval-after-load 'sly

--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -339,6 +339,7 @@ in the directory of the current buffer."
     (setf sly-last-compilation-result result) ;; For interactive use
     (when sly-highlight-compiler-notes
       (sly-highlight-notes notes))
+    (when message (message message))
     ;; Conditionally show compilation log and other options defined in settings
     (run-hook-with-args 'sly-compilation-finished-hook successp notes buffer t)))
 


### PR DESCRIPTION
1. Replace now obsolete call to `tags-query-replace`.
2. Fix unused `_message` and `message` parameters.