### PR TITLE
Remove coupling between sly-asdf proper and flymake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ Installing manually will require the contrib be registered in SLY's `sly-contrib
 SLY-ASDF currently supports a very experimental system-aware checker that builds on flymake. This loads the system in a separate process and highlights any compilation/load errors for currently opened buffers. Only tested with SBCL. Enable this with 
 ```
 (setq sly-asdf-enable-experimental-syntax-checking t)
+(require 'sly-asdf-flymake)
 ```

--- a/sly-asdf-flymake.el
+++ b/sly-asdf-flymake.el
@@ -6,9 +6,6 @@
 
 (defvar sly-asdf-enable-experimental-syntax-checking nil)
 
-(defvar *sly-asdf-lisp-extensions* (list "lisp")
-  "File extensions to look for when finding open Lisp files.")
-
 (defvar sly-asdf--buffer-to-system (make-hash-table))
 (defvar sly-asdf--system-to-buffers (make-hash-table))
 (defvar sly-asdf--last-lisp-buffers nil)
@@ -304,15 +301,12 @@ not pass the diagnostic's buffer to `make-overlay`."
           (popup-tip (sly-asdf-flymake-base-diagnostic-text (car diags)) :point point))))))
 
 
+;; Activate (upon value of `sly-asdf-enable-experimental-syntax-checking')
+(add-hook 'sly-connected-hook
+          ;; MG: Investigate race, due to when ASDF loads?
+          ;; OC: Is this still a problem after decoupling from sly-asdf?
+          (lambda () (run-with-idle-timer .5 nil #'sly-asdf-flymake)))
 
-(defun sly-asdf--lisp-buffer-p (buffer)
-  "Check whether BUFFER refers to a Lisp buffer."
-  (member (file-name-extension (buffer-name buffer)) *sly-asdf-lisp-extensions*))
-
-
-(defun sly-asdf--current-lisp-buffers ()
-  "Traverses the current `buffer-list`, returning those buffers with a .lisp extension."
-  (cl-remove-if-not #'sly-asdf--lisp-buffer-p (buffer-list)))
 
 
 (provide 'sly-asdf-flymake)

--- a/sly-asdf.el
+++ b/sly-asdf.el
@@ -32,7 +32,6 @@
 (require 'sly)
 (require 'cl-lib)
 (require 'grep)
-(require 'sly-asdf-flymake)
 
 (defvar sly-mrepl-shortcut-alist) ;; declared in sly-mrepl
 
@@ -58,11 +57,21 @@
   (:license "GPL")
   (:slynk-dependencies slynk-asdf)
   (:on-load
-   (add-hook 'sly-connected-hook
-             ;; MG: Investigate race, due to when ASDF loads?
-             (lambda () (run-with-idle-timer .5 nil #'sly-asdf-flymake)))
    (setq sly-mrepl-shortcut-alist
          (append sly-mrepl-shortcut-alist sly-asdf-shortcut-alist))))
+
+
+(defvar *sly-asdf-lisp-extensions* (list "lisp")
+  "File extensions to look for when finding open Lisp files.")
+
+(defun sly-asdf--lisp-buffer-p (buffer)
+  "Check whether BUFFER refers to a Lisp buffer."
+  (member (file-name-extension (buffer-name buffer)) *sly-asdf-lisp-extensions*))
+
+
+(defun sly-asdf--current-lisp-buffers ()
+  "Traverses the current `buffer-list`, returning those buffers with a .lisp extension."
+  (cl-remove-if-not #'sly-asdf--lisp-buffer-p (buffer-list)))
 
 
 ;;; Interactive functions


### PR DESCRIPTION
Reason for doing this: Be able to ship just the part that depends on sly
proper, and nothing else (outside of Emacs' core packages), i.e., not on
Flymake nor popup. This will allow me to prepare an official FreeBSD port easily.

To achieve this, I removed the `require' on sly-asdf-flymake in sly-asdf, as
well as calls to the former's functions (moved to the latter). Some functions
and variables from sly-asdf-flymake had to be moved into sly-asdf.

From users' point of view, the only thing that changes is that they need to
explicitly `require` sly-asdf-flymake, in addition to setting
`sly-asdf-enable-experimental-syntax-checking` to t (this variable could now be
removed).

I left the dependency on popup in 'sly-asdf.el'. Maybe the Flymake part can be
put in a separate package. Flymake should probably be added as an explicit
dependency of sly-asdf or of the new package.