### PR TITLE
Remove extra call to PATHNAME-NAME

### DIFF
--- a/slynk-asdf.lisp
+++ b/slynk-asdf.lisp
@@ -96,7 +96,11 @@ Record compiler notes signalled as `compiler-condition's."
 AND in its source-registry. (legacy name)"
   (unique-string-list
    (mapcar
-    #'pathname-name
+    (lambda (asd)
+      (typecase asd
+        (pathname (pathname-name asd))
+        (string asd)
+        (t asd)))
     (while-collecting (c)
                       (loop for dir in asdf:*central-registry*
                          for defaults = (eval dir)


### PR DESCRIPTION
This was causing wrong results for system names containing '.' when using the load-system shortcut

Test like this:

1. `mkdir -p ~/common-lisp/foo.bar.baz/src/`
2. `touch ~/common-lisp/foo.bar.baz/src/foo.bar.baz.asd`
3. `M-x slime`
4. `M-x slime-load-system foo TAB`
5. `foo.bar.baz` should appear in the `*Completions*` buffer

See https://github.com/slime/slime/issues/609